### PR TITLE
Fixed some peculiarities in ship characteristics in the database before rendering

### DIFF
--- a/src/Views/Skill Planner/SkillDatasource/ShipAttributeDatasource.m
+++ b/src/Views/Skill Planner/SkillDatasource/ShipAttributeDatasource.m
@@ -110,6 +110,84 @@
 	return [ary objectAtIndex:index];
 }
 
+// Special preprocessing for values from the database
+// (which sometimes have some weird format)
+- (NSMutableString*)renderValue: (id)item
+{
+	NSMutableString *str = [[[NSMutableString alloc]init]autorelease];
+	NSString *unit = [item unitDisplay];
+	NSString *dn = [item displayName];
+    
+	if ([dn isEqualToString:@"Rig Size"]) {
+		// show rig size as a word, not as a number
+		double raw_val = [item valueFloat];
+		NSString *val;
+		if (raw_val == 1.0){
+			val = @"small";
+		}
+		else if (raw_val == 2.0){
+			val = @"medium";
+		}
+		else if (raw_val == 3.0){
+			val = @"large";
+		}
+		else if (raw_val == 4.0){
+			val = @"capital";
+		}
+		else{
+			[val initWithFormat:@"%.2f",raw_val];
+		}
+		[str appendString:val];
+	}
+	else if ([dn isEqualToString:@"Maximum Targeting Range"]) {
+		// show targeting range in kilometers
+		[str appendFormat:@"%.2f km",(double)[item valueFloat] / 1000];
+	}
+	else if ([dn hasSuffix:@"esistance"]) {
+		// show shield resistance the way it's shown in game
+		double raw_val = (1.0 - [item valueFloat]) * 100;
+		double eps = 1e-6;
+		if (fabs(round(raw_val) - raw_val) < eps) {
+			[str appendFormat:@"%d%%",(int)round(raw_val)];
+		}
+		else if (fabs(round(raw_val * 10) - raw_val * 10) < eps) {
+			[str appendFormat:@"%.1f%%",raw_val];
+		}
+		else {
+			[str appendFormat:@"%.2f%%",raw_val];
+		}
+	}
+	else if ([dn hasSuffix:@"echarge time"]) {
+		// show recharge time properly (for some reason the database has value in ms with unit="s")
+		double raw_val = [item valueFloat] / 1000;
+		double eps = 1e-6;
+		if (fabs(round(raw_val) - raw_val) < eps) {
+			[str appendFormat:@"%d",(int)round(raw_val)];
+		}
+		else if (fabs(round(raw_val * 10) - raw_val * 10) < eps) {
+			[str appendFormat:@"%.1f",raw_val];
+		}
+		else {
+			[str appendFormat:@"%.2f",raw_val];
+		}
+		[str appendFormat:@" %@",unit];
+	}
+	else {
+		// just render the value depending on its type
+		if([item valueInt] != NSIntegerMax){
+			[str appendFormat:@"%ld",[item valueInt]];
+		}else{
+			[str appendFormat:@"%.2f",(double)[item valueFloat]];
+		}
+        
+		if(unit != nil){
+			[str appendFormat:@" %@",unit];
+		}
+	}
+    
+	return str;
+}
+
 - (id)outlineView:(NSOutlineView *)outlineView 
 objectValueForTableColumn:(NSTableColumn *)tableColumn 
 		   byItem:(id)item
@@ -119,21 +197,7 @@ objectValueForTableColumn:(NSTableColumn *)tableColumn
 			return [item displayName];
 		}
 		if([[tableColumn identifier]isEqualToString:@"ATTR_VALUE"]){
-			NSMutableString *str = [[[NSMutableString alloc]init]autorelease];
-			
-			if([item valueInt] != NSIntegerMax){
-				[str appendFormat:@"%ld",[item valueInt]];
-			}else{
-				[str appendFormat:@"%.2f",(double)[item valueFloat]];
-			}
-			
-			NSString *unit = [item unitDisplay];
-			
-			if(unit != nil){
-				[str appendFormat:@" %@",unit];
-			}
-			
-			return str;
+            return [self renderValue: item];
 		}
 	}
 	


### PR DESCRIPTION
Namely:
- Rig size is rendered as a word instead of a number
- Maximum targeting range is rendered in kilometers
- Resistance percentages are rendered correctly as percentages (currently they are shown as parts of 1, but with % signs)
- Fixed units for capacitor and shield recharge times
