### PR TITLE
Start of appledoc-ification of .h files

### DIFF
--- a/src/Core/Account.h
+++ b/src/Core/Account.h
@@ -22,23 +22,28 @@
 @class Character;
 @class CharacterTemplate;
 
+/**
+ *  The `AccountUpdateDelegate` protocol defines messages used to notify receivers
+ *  of completed API operations.
+ */
+
 @protocol AccountUpdateDelegate
 
-/*
-	passes in the Account* object when the account finishes updating
-	didSucceed: YES on successful download, NO on error
- */
+/**
+*  Tells the delegate when the account has finished updating.
+*
+*  @param acct    The `Account` object that was updated
+*  @param success `YES` on successful download, `NO` on error
+*/
 
 -(void) accountDidUpdate:(id)acct didSucceed:(BOOL)success;
 
 @end
 
-
-/*
-	An Account object contains all the characters for a given account
-	Create this object to fetch all the characters for that account.
-	then, you can pick and choose what characters you care about for that account
-*/
+/**
+ *  The `Account` object is used to retrieve the user's character information
+ *  from the EVE Online API.
+ */
 
 @interface Account : NSObject <NSCoding> { //<NSTableViewDataSource, NSCoding> {
 	NSString *keyID;
@@ -51,28 +56,94 @@
 	id <AccountUpdateDelegate> delegate;
 }
 
+/**
+ *  The key ID for this account's API key, as provided by the EVE Online
+ *  API key manangement interface.
+ */
 @property (retain) NSString* keyID;
+
+/**
+ *  The verification code for this account's API key, as provided by the EVE Online
+ *  API key manangement interface.
+ */
 @property (retain) NSString* verificationCode;
+
+/**
+ *  A user-supplied label used to identify this account; not passed to the server.
+ */
 @property (retain) NSString* accountName;
+
+/**
+ *  The characters assigned to this account.
+ */
 @property (retain) NSMutableArray *characters;
 
-/*This sets up the internal variables, it does not populate the characters*/
+/**
+ *  @name Initialization
+ */
+
+/**
+ *  Initializes the `Account` object; does not populate the character information.
+ *
+ *  @param acctID The account's key ID.
+ *  @param key    The account's verification code.
+ *
+ *  @return A new `Account` corresponding to the provided API key.
+ */
 -(Account*) initWithDetails:(NSString*)acctID acctKey:(NSString*)key;
+
+/**
+ *  Initializes the `Account` object; does not populate the character information.
+ *
+ *  @param name The account's user-provided name.
+ *
+ *  @return A new `Account` with the provided account name.
+ */
 -(Account*) initWithName:(NSString*)name;
 
-/*
-	Refresh from disk (if the file exists). if not, download from the web
-	returns
-		YES if loaded from disk. deleagte will not be called.
-		NO if downloading from API site. delegate will be called
+/**
+ *  @name Load Account Details
  */
--(void) loadAccount:(id<AccountUpdateDelegate>)del; /*read xml file off disk*/
+
+/**
+ *  Loads the account's information from the API.
+ *
+ *  @param del An `AccountUpdateDelegate` to be notified when the update is complete.
+ */
+-(void) loadAccount:(id<AccountUpdateDelegate>)del;
+
+/**
+ *  Loads the account's information from the API.
+ *
+ *  @param del   An `AccountUpdateDelegate` to be notified when the update is complete.
+ *  @param modal `YES` if the API is being called from a modal window; `NO` otherwise.
+ */
 -(void) loadAccount:(id<AccountUpdateDelegate>)del runForModalWindow:(BOOL)modal;
 
-/*Force redownload from web*/
+/**
+ *  Loads the account's information from the API.
+ *
+ *  @param del An `AccountUpdateDelegate` to be notified when the update is complete.
+ */
 -(void) fetchCharacters:(id<AccountUpdateDelegate>)del;
 
+/**
+ *  @name Get Character Information
+ */
+
+/**
+ *  Returns the number of characters on this account.
+ *
+ *  @return The number of characters.
+ */
 -(NSInteger) characterCount;
+
+/**
+ *  Returns the characters on this account.
+ *
+ *  @return An `NSMutableArray` containing a `CharacterTemplate` for each character
+ *  on this account.
+ */
 -(NSMutableArray*) characters;
 
 
@@ -80,7 +151,13 @@
 	//- (NSInteger)numberOfRowsInTableView:(NSTableView *)aTableView;
 	//- (id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex;
 
-/*find a character in this account with the given name*/
+/**
+ *  Find a character on this account.
+ *
+ *  @param charName The name of the desired character.
+ *
+ *  @return A `CharacterTemplate` corresponding to the requested character, or `nil` if not found.
+ */
 -(CharacterTemplate*) findCharacter:(NSString*)charName;
 
 

--- a/src/Core/CharacterTemplate.h
+++ b/src/Core/CharacterTemplate.h
@@ -19,6 +19,9 @@
 
 #import <Cocoa/Cocoa.h>
 
+/**
+ The `CharacterTemplate` class associates a monitored character with its API key.
+ */
 
 @interface CharacterTemplate : NSObject<NSCoding> {
 	NSString *characterName;
@@ -29,11 +32,34 @@
 	BOOL primary;
 }
 
+/**
+ The character's name.
+ */
 @property (retain) NSString* characterName;
+
+/**
+ The character's database ID.
+ */
 @property (retain) NSString* characterId;
+
+/**
+ The API key's key ID.
+ */
 @property (retain) NSString* accountId;
+
+/**
+ The API key's verification code.
+ */
 @property (retain) NSString* verificationCode;
+
+/**
+ Whether the character is currently being monitored by Vitality.
+ */
 @property BOOL active;
+
+/**
+ This field is currently unused.
+ */
 @property BOOL primary;
 
 -(CharacterTemplate*) initWithDetails:(NSString*)name 

--- a/src/Core/Config.h
+++ b/src/Core/Config.h
@@ -23,6 +23,10 @@
 #import "Account.h"
 #import "macros.h"
 
+/**
+ The `Config` class defines a singleton object that stores application configuration
+ information.
+ */
 @interface Config : NSObject {
 	NSString *programName;
 	
@@ -37,66 +41,187 @@
 
 @property (retain) NSMutableArray* accounts;
 
+/**
+ @name Access the Configuration Object
+ */
+
+/**
+ Get the configuration object.
+ 
+ @return A pointer to the singleton `Config` object.
+ */
 +(Config*) sharedInstance;
 
+/**
+ @name Construct API URLs
+ */
 
-/*
-	Construct a URL with the required API keys to get a XML page for a character.
-	xmlPage should be in the form of @"/foo/bar.xml".  see macros.h for the page macros
+/**
+ Constructs an API URL to access character information.
+ 
+ `macros.h` provides constants for the available API calls that can be passed as
+ the `xmlPage` parameter.
+
+ 
+ @param xmlPage          The API endpoint to call, e.g. `@"/account/Characters.xml.aspx"`.
+ @param accountId        The account's API key ID.
+ @param verificationCode The account's API verification code.
+ @param characterId      The API's `characterID` value for the desired character, or `nil` if not applicable.
+ 
+ @return A URL that will call the provided endpoint.
  */
 +(NSString*) getApiUrl:(NSString*)xmlPage 
 			 keyID:(NSString*)accountId 
 				verificationCode:(NSString*)verificationCode 
 				charId:(NSString*)characterId;
 
-
-/*
-	Supply the final xml file name, and all the subpath components as variable arguments
- eg
-	getFilePath:XMLAPI_CHAR_SHEET,"foo","bar",nil;
- 
- will generate the path
- /Users/username/Library/Application Data/EveApi/foo/bar/CharacterSheet.xml.aspx
- 
- (the /char/ will be stripped off the XMLAPI_CHAR_SHEET string)
- 
- the last parameter MUST be nil or BAD THINGS will happen
+/**
+ @name Work with File Paths
  */
-+(NSString*) filePath:(NSString*)xmpApiFile, ...;
 
-/*this will return the base directory for a particular character*/
+/**
+ Compose a file path in the application's local storage directory.
+ 
+ Example:
+ 
+ [Config getFilePath:XMLAPI_CHAR_SHEET,"foo","bar",nil]
+ 
+ returns `@"/Users/username/Library/Application Support/Vitality/foo/bar/CharacterSheet.xml.aspx"`
+ 
+ @warning The last parameter passed must be `nil` or Bad Things will happen.
+ @param ... The components of the path to create the file under, terminated by `nil`.
+ 
+ @param xmlApiFile The file's base name.
+ 
+ @return The composed pathname to be created.
+ */
++(NSString*) filePath:(NSString*)xmlApiFile, ...;
+
+/**
+ Get the path for the directory containing a character's information on disk.
+ 
+ @param accountId   The character's account ID.
+ @param characterId The character's character ID.
+ 
+ @return The character's base directory.
+ */
 +(NSString*) charDirectoryPath:(NSString*)accountId character:(NSString*)characterId;
 
+/**
+ Get the file path for a file in the local storage directory.
+ 
+ @param file A constant from `macros.h`.
+ 
+ @return The requested file's full path.
+ */
 +(NSString*) buildPathSingle:(NSString*)file;
 
+/**
+ @name Manage API Accounts
+ */
 
-/*returns the array index*/
+/**
+ Add an API account to the configuration.
+ 
+ @param acct The `Account` to be added.
+ 
+ @return The index of the account if added, or -1 if already present.
+ */
 -(NSInteger) addAccount:(Account*)acct;
+
+/**
+ Remove an API account from the configuration.
+ 
+ @param acct The `Account` to be removed.
+ 
+ @return `YES` if the account was found and removed; `NO` if the account was not found.
+ */
 -(BOOL) removeAccount:(Account*)acct;
+
+/**
+ Remove all API accounts from the configuration.
+ 
+ @return `TRUE`.
+ */
 -(BOOL) clearAccounts;
 
-/*YES if all the required files exist*/
+/**
+ @name Manage Local Storage
+ */
+
+/**
+ Check for downloaded copies of the skill and certificate trees.
+ 
+ @return `YES` if both have been downloaded; `NO` otherwise.
+ */
 -(BOOL) requisiteFilesExist;
 
-/*save the config out to disk*/
+/**
+ Save the configuration to disk.
+ 
+ Doesn't actually do anything.
+ 
+ @return `YES`
+ */
 -(BOOL) saveConfig;
-/*read it back in*/
+
+/**
+ Load the configuration from disk.
+ 
+ @return `YES`
+ */
 -(BOOL) readConfig;
 
 //-(NSString*) itemDBFallbackPath;
+
+/**
+ @name Get Active Characters
+ */
 
 /*return a list of all the active characters  (CharacterTemplate)*/
 -(NSArray*) activeCharacters;
 
 
-
+/**
+ @name Ship and Icon Graphics
+ */
 
 /*functions for ship and icon graphics*/
 
+/**
+ Get the path in local storage for the image corresponding to a specified inventory type. Does not retrieve the image from EVE Online if it has not yet been downloaded.
+ 
+ @param typeID A typeID from the InvTypes table.
+ 
+ @return The path for the image on disk.
+ */
 -(NSString*) pathForImageType:(NSInteger)typeID;
+
+/**
+ Get the API URL for the image corresponding to a specified inventory type.
+ 
+ @param typeID A typeID from the InvTypes table.
+ 
+ @return The URL of the desired image on the EVE Online server.
+ */
 -(NSString*) urlForImageType:(NSInteger)typeID;
 
+/**
+ @name Database Language
+ */
+
+/**
+ Get the current database language.
+ 
+ @return A `DatabaseLanguage` corresponding to the currently-set language: `l_EN`, `l_DE`, or `l_RU`.
+ */
 -(enum DatabaseLanguage) dbLanguage;
+
+/**
+ Set the database language
+ 
+ @param lang A `DatabaseLanguage`: `l_EN`, `l_DE`, or `l_RU`.
+ */
 -(void) setDbLanguage:(enum DatabaseLanguage)lang;
 
 @end

--- a/src/Core/GlobalData.h
+++ b/src/Core/GlobalData.h
@@ -22,14 +22,9 @@
 
 #import "SkillTree.h"
 
-/*
- This singleton class is designed to hold global lookup data.
- Things such as the:
- 
-	SkillTree.
-	Certeficates.
-	CCP Database.
-	Date Formatting.
+/**
+ The `GlobalData` singleton object holds global lookup data, such as the
+ skill tree and certificates information.
  */
 
 @class SkillTree;
@@ -50,10 +45,35 @@
 @property (nonatomic, retain) CCPDatabase* database;
 @property (nonatomic, retain) NSDateFormatter* dateFormatter;
 
+/**
+ @name Access the GlobalData Object
+ */
+
+/**
+ Get the data object.
+ 
+ @return A pointer to the singleton `GlobalData` object.
+ */
 +(GlobalData*) sharedInstance;
 
 -(NSString*) formatDate:(NSDate*)date;
+
+/**
+ @name Check Database Version
+ */
+
+/**
+ Return the local database copy's version number.
+ 
+ @return The database version.
+ */
 -(NSInteger) databaseVersion;
+
+/**
+ Check whether the database is sufficiently current.
+ 
+ @return `YES` if the local database copy meets this program's minimum version requirement; `NO` otherwise.
+ */
 -(BOOL) databaseUpToDate;
 
 @end

--- a/src/Core/Helpers.h
+++ b/src/Core/Helpers.h
@@ -21,27 +21,115 @@
 
 #include "macros.h"
 
-/*return a roman numeral string for a number. eg @"3" returns @"III" */
+/**
+ @name Roman Numerals
+ */
+
+/**
+ Return the Roman numerals corresponding to Arabic numbers.
+ 
+ Example:
+ 
+    romanForString(@"3")
+ 
+ returns `@"III"`.
+ 
+ @param value A number expressed as an NSString of Arabic numerals.
+ 
+ @return The same number expressed with Roman numerals.
+ */
 NSString* romanForString(NSString *value);
+
+/**
+ Converts an integer to Roman numerals.
+ 
+ Example:
+ 
+ romanForInteger(3)
+ 
+ returns `@"III"`.
+ 
+ @param value An `NSInteger` to be converted.
+ 
+ @return The same number expressed with Roman numerals.
+ */
 NSString* romanForInteger(NSInteger value);
 
 /*
-	these are to convert strings such as "memory" into integers for storage. see
-	macros.h for valid values
+ @name Attribute Codes
+ */
+
+/**
+ Returns the database code for a given attribute.
+ 
+ @param str An attribute string constant from `macros.h`.
+ 
+ @return The attribute's integer code.
  */
 NSInteger attrCodeForString(NSString *str);
+
+/**
+ Returns the attribute name for a given attribute code.
+ 
+ @param code An attribute code as returned by `attrCodeForString`.
+ 
+ @return The attribute's string constant from `macros.h`.
+ */
 NSString* strForAttrCode(NSInteger code);
+
+/**
+ Returns the internal attribute code for an attribute code from the EVE Online database dump.
+ 
+ @param dbcode An attribute code from the database dump.
+ 
+ @return The matching internal attribute code from `macros.h`, or 0 if the provided code is invalid.
+ */
 NSInteger attrCodeForDBInt(NSInteger dbcode);
 
+/**
+ @name Directory Creation
+ */
+
+/**
+ Creates a directory at the given path, and intermediate directories if required.
+ 
+ @param path The full pathname of the directory to be created.
+ 
+ @return `YES` if successful, or `NO` otherwise.
+ */
 BOOL createDirectory(NSString *path);
 
-/*the skill points required for a particular level*/
+/**
+ @name Skill Points
+ */
+
+/**
+ Return the number of skill points required to advance a skill one level.
+ 
+ @param skillLevel The level to be trained to, from 1 to 5.
+ @param skillRank  The skill's training-time multiplier, from 1 to 16.
+ 
+ @return The number of skill points required to advance from `skillLevel - 1` to `skillLevel`.
+ */
 NSInteger skillPointsForLevel(NSInteger skillLevel, NSInteger skillRank);
-/*the total skill points up to a particular level*/
+
+/**
+ Return the number of skill points required to advance a skill to the specified level from level 0.
+ 
+ @param skillLevel The level to be trained to, from 1 to 5.
+ @param skillRank  The skill's training-time multiplier, from 1 to 16.
+ 
+ @return The number of skill points required to advance from 0 to `skillLevel`.
+ */
 NSInteger totalSkillPointsForLevel(NSInteger skillLevel, NSInteger skillRank);
 
-/*given the number of seconds, return a string describing how long it will take to train*/
+/**
+ @name Training Time
+ */
 
+/**
+ Constants with which to construct a bitmask for `stringTrainingTime2`.
+ */
 enum TrainingTimeFields
 {
 	TTF_Days = (1 << 1),
@@ -51,12 +139,61 @@ enum TrainingTimeFields
 	TTF_All = 0xFFFFFFFF
 };
 
-NSString* stringTrainingTime2(NSInteger trainingTime , enum TrainingTimeFields ttf);
+/**
+ Convert a time in seconds to a string representation.
+ 
+ @param trainingTime The time to be displayed, in seconds.
+ @param ttf          A bitmask identifying the `TrainingTimeFields` to be included.
+ 
+ @return A string representation of `trainingTime`.
+ */
+NSString* stringTrainingTime2(NSInteger trainingTime, enum TrainingTimeFields ttf);
+
+/**
+ Convert a time in seconds to a string representation.
+ 
+ @param trainingTime The time to be displayed, in seconds.
+ 
+ @return A string representation of `trainingTime` in the form "0d 0h 0m 0s".
+ */
 NSString* stringTrainingTime(NSInteger trainingTime);
 
+/**
+ Return the progress of a skill level's training.
+ 
+ @param startingPoints  The number of skill points at which training commenced.
+ @param finishingPoints The number of skill points at which training will be completed.
+ @param currentPoints   The current number of skill points.
+ 
+ @return The current level's progress, from 0.0 to 1.0.
+ */
 CGFloat skillPercentCompleted(NSInteger startingPoints, NSInteger finishingPoints, NSInteger currentPoints);
 
+/**
+ Wrapper for `sqlite3_column_text` that returns an `NSString`.
+ 
+ @param stmt The SQLite prepared statement being evaluated.
+ @param col  The index of the text column to return.
+ 
+ @return The contents of the specified column.
+ */
 NSString* sqlite3_column_nsstr(void *stmt, int col);
 
+/**
+ Returns the language corresponding to a `DatabaseLanguage` member.
+ 
+ @param lang A `DatabaseLanguage` member.
+ 
+ @return The human-readable name of the language corresponding to `lang`.
+ */
 NSString* languageForId(enum DatabaseLanguage lang);
+
+/**
+ Returns the ISO-639-2 language code corresponding to a database
+ language.
+ 
+ @param lang A `DatabaseLanguage` member.
+ 
+ @return The corresponding ISO-639-2 code, in upper-case, or `NULL` if English.
+ */
 const char* langCodeForId(enum DatabaseLanguage lang);

--- a/src/Core/MTAPIKey.h
+++ b/src/Core/MTAPIKey.h
@@ -21,24 +21,28 @@
 
 @class MTAPIKey;
 
+/**
+ The method specified by `APIKeyValidationDelegate` can be used to receive the results
+ of API-key validation.
+ */
 @protocol APIKeyValidationDelegate
 
-/*
-	Returns results of checking the given API key for validity.
-    Mosly checking for the right permissions.
- */
 
+/**
+ Report the results of API-key validation.
+ 
+ @param key     The API key that was checked for validity.
+ @param success `YES` if the key is valid; `NO` otherwise.
+ @param error   If unsuccessful, may provide additional information about the failure.
+ */
 -(void) key:(MTAPIKey *)key didValidate:(BOOL)success withError:(NSError *)error;
 
 @end
 
 
-/*
-	An Account object contains all the characters for a given account
-	Create this object to fetch all the characters for that account.
-	then, you can pick and choose what characters you care about for that account
-*/
-
+/**
+ The `MTAPIKey` object is used by the `AccountPrefDetailController` to store an API key.
+ */
 @interface MTAPIKey : NSObject
 {
 	NSString *keyID;
@@ -51,15 +55,63 @@
 	id <APIKeyValidationDelegate> delegate;
 }
 
+/**
+ @name Properties
+ */
+
+/**
+ The API key ID.
+ */
 @property (retain) NSString* keyID;
+
+/**
+ The API key verification code.
+ */
 @property (retain) NSString* verificationCode;
+
+/**
+ The API key access mask.
+ */
 @property (retain,readonly) NSString *mask;
+
+/**
+ The API key's type.
+ 
+ Valid types:
+ 
+ - `@"Character"`
+ - `@"Corporation"`
+ 
+ */
 @property (retain,readonly) NSString *type;
+
+/**
+ The API key's expiration date.
+ */
 @property (retain,readonly) NSDate *expires;
 
-/*This sets up the internal variables, it does not populate the characters*/
+/**
+ @name Initialization
+ */
+
+/**
+ Initialize the `MTAPIKey` object; does not call the API.
+ 
+ @param _keyID    The API key ID.
+ @param code      The API validation code.
+ @param _delegate The delegate to be called when the `validate` method completes.
+ 
+ @return Self.
+ */
 -(MTAPIKey *) initWithID:(NSString*)_keyID code:(NSString*)code delegate:(id<APIKeyValidationDelegate>)_delegate;
 
+/**
+ @name Validate Key
+ */
+
+/**
+ Validate the provided key against the EVE Online server.
+ */
 -(void) validate;
 
 

--- a/src/Core/ServerMonitor.h
+++ b/src/Core/ServerMonitor.h
@@ -21,6 +21,14 @@
 
 #import "macros.h"
 
+/**
+ `ServerMonitor` is used to query the operating status and number of players logged in
+ to the EVE Online server.
+ 
+ When monitoring is started, `ServerMonitor` periodically polls the server and posts a
+ notification to the default `NSNotificationCenter` after each poll.
+ */
+
 @interface ServerMonitor : NSObject {
 	enum ServerStatus status;
 	NSInteger numPlayers;
@@ -32,9 +40,26 @@
 @property (nonatomic,readonly) enum ServerStatus status;
 @property (nonatomic,readonly) NSInteger numPlayers;
 
+/**
+ Poll the server. The results will become available in this object's properties once the
+ poll returns; callers must subscribe to SERVER_STATUS_NOTIFICATION notifications to
+ be informed of this function's completion.
+ */
 -(void) checkServerStatus;
 
+/**
+ Start monitoring the server's status. When monitoring, the server will be polled
+ every 300 seconds.
+ 
+ To retrieve the results of the poll, callers should subscribe to
+ SERVER_STATUS_NOTIFICATION notifications and check this object's properties
+ once that notification is received.
+ */
 -(void) startMonitoring;
+
+/**
+ Stop monitoring the server's status.
+ */
 -(void) stopMonitoring;
 
 @end

--- a/src/Vitality.xcodeproj/project.pbxproj
+++ b/src/Vitality.xcodeproj/project.pbxproj
@@ -30,6 +30,17 @@
 			name = Package;
 			productName = Package;
 		};
+		CD8ECF3818B98D2D006AA8EE /* Documentation */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = CD8ECF3C18B98D2D006AA8EE /* Build configuration list for PBXAggregateTarget "Documentation" */;
+			buildPhases = (
+				CD8ECF3D18B98DA2006AA8EE /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = Documentation;
+			productName = Documentation;
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
@@ -1107,6 +1118,7 @@
 				8D1107260486CEB800E47090 /* Vitality */,
 				C9F51595105682AB00654F6D /* Package */,
 				C9AB3DEC1120E9840057523C /* Languages */,
+				CD8ECF3818B98D2D006AA8EE /* Documentation */,
 			);
 		};
 /* End PBXProject section */
@@ -1183,6 +1195,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# shell script goes here\n\nDEPLOYDIR=/Users/matt/programming/deployment\n\nFILELEN=`$DEPLOYDIR/length \"$DEPLOYDIR/MacEveApi.zip\"`\nCURDATE=`date +\"%Y-%m-%d %H:%M:%S +1000\"`\n\nrm -f \"$DEPLOYDIR/MacEveApi.zip\"\nrm -f \"$DEPLOYDIR/Mac Eve Tools.dmg\"\nrm -f \"$DEPLOYDIR/Mac Eve Tools.zip\"\nrm -rf /tmp/MacEveApi\nmkdir /tmp/MacEveApi\n\n#cp '/Users/matt/Downloads/Sparkle 1/License.txt' '/tmp/MacEveApi/Sparkle License.txt'\ncp ReleaseNotes.txt /tmp/MacEveApi\ncp ReleaseNotes.txt $DEPLOYDIR\ncp Readme.rtf /tmp/MacEveApi\ncp -R \"$TARGET_BUILD_DIR/Mac Eve Tools.app\" '/tmp/MacEveApi'\n\nhdiutil create -fs HFS+ -volname \"Mac Eve Tools\" -srcfolder /tmp/MacEveApi/  -format UDBZ \"$DEPLOYDIR/Mac Eve Tools.dmg\"\n\n#generate upgrade zipfile\nOLDDIR=`pwd`\ncd '/tmp/MacEveApi'\nzip -r -9 -y -T  \"$DEPLOYDIR/MacEveApi.zip\" 'Mac Eve Tools.app'\ncd $OLDDIR\nDSASIG=`ruby $DEPLOYDIR/sign_update.rb \"$DEPLOYDIR/MacEveApi.zip\" $DEPLOYDIR/dsa_priv.pem`\n\n#generate appcast xml\npython $DEPLOYDIR/appcast.py -v $CURRENT_PROJECT_VERSION -t \"MacEveApi Release:$CURRENT_PROJECT_VERSION\" -l $FILELEN -s $DSASIG -d \"$CURDATE\" > $DEPLOYDIR/APPCAST.XML\n\nexit 0";
+		};
+		CD8ECF3D18B98DA2006AA8EE /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Start constants\ncompany=\"Vitality\";\ncompanyID=\"org.Vitality\";\ncompanyURL=\"https://github.com/sixones/vitality\";\n#target=\"iphoneos\";\ntarget=\"macosx\";\noutputPath=\"~/help\";\n# End constants\n/usr/local/bin/appledoc \\\n--project-name \"${PROJECT_NAME}\" \\\n--project-company \"${company}\" \\\n--company-id \"${companyID}\" \\\n--docset-atom-filename \"${company}.atom\" \\\n--docset-feed-url \"${companyURL}/${company}/%DOCSETATOMFILENAME\" \\\n--docset-package-url \"${companyURL}/${company}/%DOCSETPACKAGEFILENAME\" \\\n--docset-fallback-url \"${companyURL}/${company}\" \\\n--output \"${outputPath}\" \\\n--publish-docset \\\n--docset-platform-family \"${target}\" \\\n--logformat xcode \\\n--keep-intermediate-files \\\n--no-repeat-first-par \\\n--no-warn-invalid-crossref \\\n--exit-threshold 2 \\\n\"${PROJECT_DIR}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1677,6 +1702,27 @@
 			};
 			name = Release;
 		};
+		CD8ECF3918B98D2D006AA8EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		CD8ECF3A18B98D2D006AA8EE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		CD8ECF3B18B98D2D006AA8EE /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Test Release";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1719,6 +1765,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		CD8ECF3C18B98D2D006AA8EE /* Build configuration list for PBXAggregateTarget "Documentation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CD8ECF3918B98D2D006AA8EE /* Debug */,
+				CD8ECF3A18B98D2D006AA8EE /* Release */,
+				CD8ECF3B18B98D2D006AA8EE /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
This commit just has src/Core/*.h, but others will follow.

Benefits: Enables automated generation of docset, and appledoc shows up in the Quick Help inspector in XCode.

The new build scheme (Documentation) currently produces a bunch of warnings, but they're all from classes I haven't touched yet that have appledoc-like comments.
