### PR TITLE
Compiling in El Capitan

### DIFF
--- a/src/Preferences/GeneralPrefViewController.h
+++ b/src/Preferences/GeneralPrefViewController.h
@@ -11,7 +11,7 @@
 #import "MainController.h"
 
 @interface GeneralPrefViewController : NSViewController <MBPreferencesModule> {
-    __weak MainController* _mainController;
+    MainController* _mainController;
 }
 
 - (NSString *)title;

--- a/src/Private/StatusItemView.h
+++ b/src/Private/StatusItemView.h
@@ -3,7 +3,7 @@
 #import "MainController.h"
 
 @interface StatusItemView : NSView {
-    __weak MainController *controller;
+    MainController *controller;
     
     BOOL opened;
 }

--- a/src/Private/StatusItemViewController.h
+++ b/src/Private/StatusItemViewController.h
@@ -24,7 +24,7 @@
     Skill *currentTrainingSkill;
     
     @private
-    __weak MainController *_mainController;
+    MainController *_mainController;
 }
 
 -(Character*) getCharacter;

--- a/src/Private/StatusItemWindow.h
+++ b/src/Private/StatusItemWindow.h
@@ -7,9 +7,9 @@
 
 @interface StatusItemWindow : NSWindow {
     @private
-    __weak StatusItemViewController* _controller;
-    __weak MainController* _mainController;
-    __weak NSView *_view;
+    StatusItemViewController* _controller;
+    MainController* _mainController;
+    NSView *_view;
     NSPoint _point;
 }
 

--- a/src/Vitality.xcodeproj/project.pbxproj
+++ b/src/Vitality.xcodeproj/project.pbxproj
@@ -1743,7 +1743,7 @@
 				PER_ARCH_CFLAGS_i386 = "";
 				PER_ARCH_CFLAGS_ppc = "";
 				PRODUCT_NAME = Vitality;
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -1768,7 +1768,7 @@
 				PER_ARCH_CFLAGS_i386 = "";
 				PER_ARCH_CFLAGS_ppc = "";
 				PRODUCT_NAME = Vitality;
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -1785,7 +1785,10 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = /usr/include/libxml2;
+				HEADER_SEARCH_PATHS = (
+					/usr/include/libxml2,
+					/usr/local/include,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -1815,8 +1818,12 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = /usr/include/libxml2;
+				HEADER_SEARCH_PATHS = (
+					/usr/include/libxml2,
+					/usr/local/include,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-lxml2",
 					"-lcrypto",
@@ -1843,8 +1850,12 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = /usr/include/libxml2;
+				HEADER_SEARCH_PATHS = (
+					/usr/include/libxml2,
+					/usr/local/include,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-lxml2",
 					"-lcrypto",
@@ -1881,7 +1892,7 @@
 				PER_ARCH_CFLAGS_i386 = "";
 				PER_ARCH_CFLAGS_ppc = "";
 				PRODUCT_NAME = Vitality;
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 			};
 			name = "Test Release";
 		};

--- a/src/vitality.plist
+++ b/src/vitality.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.7b</string>
+	<string>0.3.7c</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -42,7 +42,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.3.7b</string>
+	<string>0.3.7c</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
This should allow a proper compile using OpenSSL from HomeBrew. The libraries should be linked into /usr/local/include.

A minor version bump to 0.3.7c (up from 0.3.7b).